### PR TITLE
Add automatic converters for 64-bit types

### DIFF
--- a/Source/Attributes/Public/FloatAttributesLibrary.h
+++ b/Source/Attributes/Public/FloatAttributesLibrary.h
@@ -47,6 +47,10 @@ public:
 	UFUNCTION(BlueprintPure, Category = Attributes, meta = (DisplayName = "ToFloat (FloatAttr)", CompactNodeTitle = "->", Keywords = "get value float", BlueprintAutocast))
 	static FORCEINLINE float Conv_AttributeToFloat(const FFloatAttr& Attribute) { return GetValue(Attribute); }
 
+	// Get final value as double
+	UFUNCTION(BlueprintPure, Category = Attributes, meta = (DisplayName = "ToDouble (FloatAttr)", CompactNodeTitle = "->", Keywords = "get value double", BlueprintAutocast))
+	static FORCEINLINE double Conv_AttributeToDouble(const FFloatAttr& Attribute) { return GetValue(Attribute); }
+
 	// Get final value as String
 	UFUNCTION(BlueprintPure, Category = Attributes, meta = (DisplayName = "ToString (FloatAttr)", CompactNodeTitle = "->", BlueprintAutocast))
 	static FORCEINLINE FString Conv_AttributeToString(const FFloatAttr& Attribute) {

--- a/Source/Attributes/Public/Int32AttributesLibrary.h
+++ b/Source/Attributes/Public/Int32AttributesLibrary.h
@@ -47,6 +47,10 @@ public:
 	UFUNCTION(BlueprintPure, Category = Attributes, meta = (DisplayName = "ToInt (Int32Attr)", CompactNodeTitle = "->", Keywords = "get value int", BlueprintAutocast))
 	static FORCEINLINE int32 Conv_AttributeToInt(const FInt32Attr& Attribute) { return GetValue(Attribute); }
 
+	// Get final value as int64
+	UFUNCTION(BlueprintPure, Category = Attributes, meta = (DisplayName = "ToInt64 (Int32Attr)", CompactNodeTitle = "->", Keywords = "get value int64", BlueprintAutocast))
+	static FORCEINLINE int64 Conv_AttributeToInt64(const FInt32Attr& Attribute) { return GetValue(Attribute); }
+
 	// Get final value as String
 	UFUNCTION(BlueprintPure, Category = Attributes, meta = (DisplayName = "ToString (Int32Attr)", CompactNodeTitle = "->", BlueprintAutocast))
 	static FORCEINLINE FString Conv_AttributeToString(const FInt32Attr& Attribute) {


### PR DESCRIPTION
Since UE5 the "Float" blueprint type is now double-precision by default. Therefore, the included FloatAttr to single-precision float converter does not suffice for new and migrated blueprints variables anymore.

The default "Integer" blueprint type is still int32 internally but since there is a "Integer64" blueprint type I included it too, which makes these changes also useful for UE4 users.